### PR TITLE
Fix: #1974: Moved schema contribution guideline from nest to nest-schema repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing to OWASP Schema
 
-Thank you for considering contributing to the OWASP Schema project!
+Thank you for your interest in contributing to the OWASP Schema project - we appreciate your support!
 
 ## Getting Started
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/nest-schema.git`
-4. Install dependencies: `make install-package`
-5. Run tests to ensure everything works: `make test`
+1. Clone your fork: `git clone https://github.com/your-username/nest-schema.git`
+1. Install dependencies: `make install`
+1. Run tests to ensure everything works: `make test`
 
 ## OWASP Schema Development
 
@@ -26,32 +26,37 @@ Please follow these contribution guidelines for OWASP Schema-related changes:
 
 ## Testing and Building
 
-You can run the following commands locally:
+You can run the following commands locally.
+
+This command runs code quality checks:
+
+```bash
+make check
+```
+
+This command runs all tests for the schema validation:
 
 ```bash
 make test
 ```
 
-This command runs all tests for the schema validation.
+This command installs all required dependencies:
 
 ```bash
-make install-package
+make install
 ```
 
-This command installs all required dependencies.
+This command builds the package for distribution:
 
 ```bash
-make build-package
+make build
 ```
-
-This command builds the package for distribution.
 
 ## Development Workflow
 
 1. Create a feature branch: `git checkout -b feature/your-change`
-2. Make your schema changes
-3. Add or update tests for your changes
-4. Run tests: `make test`
-5. Commit your changes with a descriptive message
-6. Push and create a pull request
-
+1. Make your schema changes
+1. Add or update tests for your changes
+1. Run tests: `make test`
+1. Commit your changes with a descriptive message
+1. Push and create a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to OWASP Schema
+
+Thank you for considering contributing to the OWASP Schema project!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/nest-schema.git`
+4. Install dependencies: `make install-package`
+5. Run tests to ensure everything works: `make test`
+
+## OWASP Schema Development
+
+The OWASP Schema files are located in the root directory. This is a standalone `pyproject.toml` project with its own test suite.
+
+Please follow these contribution guidelines for OWASP Schema-related changes:
+
+- Order all schema attributes alphabetically where applicable.
+- Use the `common.json` definition file for shared object definitions (e.g., chapter, project).
+- Include all schema attributes in both required and optional positive test cases.
+- Add negative tests for all mandatory attributes, covering empty, invalid, null, and undefined cases.
+- Always set `additionalProperties` to `false` and list all mandatory fields in the `required` section.
+- Always add `minItems`, `minLength`, and `uniqueItems` where applicable.
+- When referencing definitions from `common.json`, test both the object's internal structure (in the `common` section) and its references in actual schemas (e.g., chapter, project).
+- Run `make test` before submitting a PR.
+
+## Testing and Building
+
+You can run the following commands locally:
+
+```bash
+make test
+```
+
+This command runs all tests for the schema validation.
+
+```bash
+make install-package
+```
+
+This command installs all required dependencies.
+
+```bash
+make build-package
+```
+
+This command builds the package for distribution.
+
+## Development Workflow
+
+1. Create a feature branch: `git checkout -b feature/your-change`
+2. Make your schema changes
+3. Add or update tests for your changes
+4. Run tests: `make test`
+5. Commit your changes with a descriptive message
+6. Push and create a pull request
+

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,24 @@ bump-minor-commit:
 bump-patch-commit:
 	poetry run bump2version patch -commit -tag -allow-dirty
 
+check: \
+    pre-commit
+
+check-test: \
+	check \
+	test
+
 clean-package:
 	rm -rf dist/ build/ *.egg-info/
 
 clean-dependencies:
 	@rm -rf .venv
 
-install-package:
+install:
 	poetry install
+
+pre-commit:
+	@pre-commit run -a
 
 publish-package:
 	poetry publish

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ print(chapter_schema["title"])
 
 This package is automatically published to PyPI when schema files change in the main branch using OIDC authentication.
 
+For development setup and contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## License
 
 MIT License - see LICENSE file for details.


### PR DESCRIPTION
Resolves [#1974](https://github.com/OWASP/Nest/issues/1974#event-18981544940).

# Description

This PR moves the schema contribution guidelines from the OWASP Nest repo to the OWASP nest-schema repo it helps keep the documentation more organized.